### PR TITLE
Added data to wp_pagenavi filter to allow for custom html.

### DIFF
--- a/core.php
+++ b/core.php
@@ -119,7 +119,7 @@ function wp_pagenavi( $args = array() ) {
 				if ( $i == $paged && ! empty( $options['current_text'] ) ) {
 					$current_page_text = str_replace( '%PAGE_NUMBER%', number_format_i18n( $i ), $options['current_text'] );
 
-					$instance->set_data( $data, $current_page_text, 'current' );
+					$data['current'] = $current_page_text;
 					$out .= "<span class='current'>$current_page_text</span>";
 					$timeline = 'larger';
 				} else {
@@ -173,7 +173,7 @@ function wp_pagenavi( $args = array() ) {
 
 				$url = esc_url( $instance->get_url( $page_num ) );
 
-				$instance->set_data( $data, $url );
+				$data[] = $url;
 
 				if ( $i == $paged ) {
 					$current_page_text = str_replace( '%PAGE_NUMBER%', number_format_i18n( $i ), $options['current_text'] );
@@ -266,9 +266,9 @@ class PageNavi_Call {
 			);
 			$meta = array_search( $class, $special_links );
 			if ( $meta )
-				$this->set_data( $data, $data_val, $meta );
+				$data[$meta] = $data_val;
 			else
-				$this->set_data( $data, $data_val );
+				$data[] = $data_val;
 		}
 
 		return "<a href='$url' class='$class'>$text</a>";
@@ -281,17 +281,9 @@ class PageNavi_Call {
 	function get_extend( $content, &$data = null ) {
 
 		if ( isset( $data ) )
-			$this->set_data( $data, $content );
+			$data[] = $content;
 
 		return "<span class='extend'>{$content}</span>";
-	}
-
-	function set_data( &$data, $content, $key = null ) {
-
-		if ( isset( $key ) )
-			$data[$key] = $content;
-		else
-			$data[] = $content;
 	}
 }
 


### PR DESCRIPTION
The current structure of the data array that is passed to the filter is:

``` php
<?php
array (
  'current' => '1',
  0 => 
  array (
    'url' => 'http://example.com/page/2/',
    'text' => '2',
  ),
  1 => 
  array (
    'url' => 'http://example.com/page/3/',
    'text' => '3',
  ),
  2 => '...',
  3 => 
  array (
    'url' => 'http://example.com/page/6/',
    'text' => '6',
  ),
  4 => 
  array (
    'url' => 'http://example.com/page/9/',
    'text' => '9',
  ),
  5 => 
  array (
    'url' => 'http://example.com/page/12/',
    'text' => '12',
  ),
  6 => '...',
  'next' => 
  array (
    'url' => 'http://example.com/page/2/',
    'text' => '»',
  ),
  'last' => 
  array (
    'url' => 'http://example.com/page/14/',
    'text' => 'Last »',
  ),
)
```

So, by filtering the html like so:

``` php
<?php
add_filter( 'wp_pagenavi', 'my_pagination', 10, 2 );
function my_pagination( $html, $pagination_data ) {

    $out = '';
    foreach ( $pagination_data as $key => $value ) {
        /** Set the default class. */
        $class = 'item';

        /** If this is a special pagination item, add the proper class. */
        if ( is_string( $key ) )
            $class .= " is-$key";
        /** If this is ..., add a special class. */
        else if ( ! is_array( $value ) )
            $class .= ' is-disabled';

        /** If this is a link, wrap in an anchor. */
        if ( is_array( $value ) )
            $value = "<a href=\"{$value['url']}\">{$value['text']}</a>";

        /** Wrap everything in a list item. */
        $out .= "<li class=\"$class\">$value</li>";
    }

    /** Return the list. */
    return "\n<ul class=\"pagination\">$out</ul>";
}
```

we can can output the pagination in a list:

``` html
<ul class="pagination">
    <li class="item is-current">1</li>
    <li class="item"><a href="http://example.com/page/2/">2</a></li>
    <li class="item"><a href="http://example.com/page/3/">3</a></li>    
    <li class="item is-disabled">...</li>
    <li class="item"><a href="http://example.com/page/6/">6</a></li>
    <li class="item"><a href="http://example.com/page/9/">9</a></li>
    <li class="item"><a href="http://example.com/page/12/">12</a></li>
    <li class="item is-disabled">...</li>
    <li class="item is-next"><a href="http://example.com/page/2/">»</a></li>
    <li class="item is-last"><a href="http://example.com/page/14/">Last »</a></li>
</ul>
```

As you can see, **currently there is no distinction between "Previous …" items and "Next …"** items. I can add this if you think it would be useful.

If a more formal structure is needed for the data array, the implementation can be changed to generate something like this:

``` php
<?php
array (
  0 => array (
    'text' => '1',
    'meta' => array( 'type' => 'current' ),
  ),
  1 => 
  array (
    'url' => 'http://example.com/page/2/',
    'text' => '2',
  ),
  2 => 
  array (
    'url' => 'http://example.com/page/3/',
    'text' => '3',
  ),
  3 => array(
    'text' => '…',
    'meta' => array( 'type' => 'next_ellipsis' ),
  )
  3 => 
  array (
    'url' => 'http://example.com/page/6/',
    'text' => '6',
  ),
  4 => 
  array (
    'url' => 'http://example.com/page/9/',
    'text' => '9',
  ),
  5 => 
  array (
    'url' => 'http://example.com/page/12/',
    'text' => '12',
  ),
  3 => array(
    'text' => '…',
    'meta' => array( 'type' => 'next_ellipsis' ),
  )
  'next' => 
  array (
    'url' => 'http://example.com/page/2/',
    'text' => '»',
    'meta' => array( 'type' => 'next' ),
  ),
  'last' => 
  array (
    'url' => 'http://example.com/page/14/',
    'text' => 'Last »',
    'meta' => array( 'type' => 'last' ),
  ),
)
```

This version works well if other information about the items needs to be added in the future (just add it in the meta array). 
