### PR TITLE
Changed wp_print_styles to wp_enqueue_scripts

### DIFF
--- a/core.php
+++ b/core.php
@@ -288,7 +288,7 @@ class PageNavi_Core {
 	static function init( $options ) {
 		self::$options = $options;
 
-		add_action( 'wp_print_styles', array( __CLASS__, 'stylesheets' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'stylesheets' ) );
 	}
 
 	static function stylesheets() {


### PR DESCRIPTION
Since WordPress 3.3, we should use wp_enqueue_scripts, not wp_print_styles, to enqueue styles for the frontend.
