### PR TITLE
Add "after last page" option

### DIFF
--- a/core.php
+++ b/core.php
@@ -24,7 +24,8 @@ function wp_pagenavi( $args = array() ) {
 		'options' => array(),
 		'query' => $GLOBALS['wp_query'],
 		'type' => 'posts',
-		'echo' => true
+		'echo' => true,
+		'afterlastpage' => ''
 	) );
 
 	extract( $args, EXTR_SKIP );
@@ -179,6 +180,16 @@ function wp_pagenavi( $args = array() ) {
 					'class' => $class_names['last'],
 				), '%TOTAL_PAGES%' );
 			}
+			
+			// Consumer binding with an option do add link "after last page"
+      			if( ($paged == $total_pages) && ($instance->afterlastpage !== '') ) {
+        			$out .= html('a', array(
+         				'class' => 'nextpostslink',
+         				'rel' => 'next',
+        				'href'  =>  $instance->afterlastpage
+        				) );
+      			}
+      			
 			break;
 
 		// Dropdown


### PR DESCRIPTION
This option allows to add a custom href/link on the last page. It's different to the $after, because it looks like the "next" button, so users can be led to a recommended follow-up page.
