### PR TITLE
[FIX] Hidden border-bottom

### DIFF
--- a/pagenavi-css.css
+++ b/pagenavi-css.css
@@ -13,6 +13,7 @@ http://wordpress.org/extend/plugins/wp-pagenavi/
 	border: 1px solid #BFBFBF;
 	padding: 3px 5px;
 	margin: 2px;
+	line-height: 25px; /* Fix bug : hidden border-bottom */
 }
 
 .wp-pagenavi a:hover, .wp-pagenavi span.current {


### PR DESCRIPTION
I saw this bug on last versions of Chrome and IE11.

![wp-pagenavi-css-bug](https://cloud.githubusercontent.com/assets/8670083/10696160/2aefac04-79a7-11e5-854a-95e1746c0c2d.png)
