### PR TITLE
Fixed 'Filter Usage' appearance on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are [filters](http://codex.wordpress.org/Glossary#Filter) that can be used
 
 #### Filter Usage
 
-```
+```php
 // Simple Usage - 1 callback per filter
 add_filter('wp_pagenavi_class_previouspostslink', 'theme_pagination_previouspostslink_class');
 add_filter('wp_pagenavi_class_nextpostslink', 'theme_pagination_nextpostslink_class');

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are [filters](http://codex.wordpress.org/Glossary#Filter) that can be used
 
 #### Filter Usage
 
-`
+```
 // Simple Usage - 1 callback per filter
 add_filter('wp_pagenavi_class_previouspostslink', 'theme_pagination_previouspostslink_class');
 add_filter('wp_pagenavi_class_nextpostslink', 'theme_pagination_nextpostslink_class');
@@ -123,7 +123,7 @@ function theme_pagination_class($class_name) {
   }
   return $class_name;
 }
-`
+```
 
 ## Screenshots
 


### PR DESCRIPTION
Added more '`' to create block of content properly.

This is just a minor change. The [https://github.com/lesterchan/wp-pagenavi#filter-usage](Filter Usage) block was hard to read. Once it had only one '`' at the beginning and at the end, I added two more to appear properly, like a block and ease reading.