### PR TITLE
Add title attr to pages link

### DIFF
--- a/core.php
+++ b/core.php
@@ -125,6 +125,7 @@ function wp_pagenavi( $args = array() ) {
 				if ( $larger_page < ($start_page - $half_page_start) && $larger_page_start < $larger_page_to_show ) {
 					$out .= $instance->get_single( $larger_page, $options['page_text'], array(
 						'class' => "{$class_names['smaller']} {$class_names['page']}",
+						'title' => sprintf( __( 'Page %d', 'wp-pagenavi' ), number_format_i18n( $larger_page ) ),
 					) );
 					$larger_page_start++;
 				}
@@ -143,6 +144,7 @@ function wp_pagenavi( $args = array() ) {
 				} else {
 					$out .= $instance->get_single( $i, $options['page_text'], array(
 						'class' => "{$class_names['page']} {$class_names[$timeline]}",
+						'title' => sprintf( __( 'Page %d', 'wp-pagenavi' ), number_format_i18n( $i ) ),
 					) );
 				}
 			}
@@ -154,6 +156,7 @@ function wp_pagenavi( $args = array() ) {
 				if ( $larger_page > ($end_page + $half_page_end) && $larger_page_end < $larger_page_to_show ) {
 					$larger_page_out .= $instance->get_single( $larger_page, $options['page_text'], array(
 						'class' => "{$class_names['larger']} {$class_names['page']}",
+						'title' => sprintf( __( 'Page %d', 'wp-pagenavi' ), number_format_i18n( $larger_page ) ),
 					) );
 					$larger_page_end++;
 				}


### PR DESCRIPTION
Hello,

A web accessibility expert from Temesis / Opquast have made an audit on a big french website (museum) and reported this following issue with WP pagenavi plugin about a11n.

It would be nice to have a title attribute explaining which page number is it for screen readers.

It would make a markup like this for example : 
`<a class="page larger" title="Page 3" href="/page/3/">3</a>`

So here I'm proposing this Pull Request to handle this behavior, I didn't have to make so much changes thanks to the current base code, and I use i18n functions to allow this new text to be translatable.

Hope to find this approved, thanks for your job 😄 