### PR TITLE
Add ARIA roles for better accessibility

### DIFF
--- a/core.php
+++ b/core.php
@@ -139,7 +139,7 @@ function wp_pagenavi( $args = array() ) {
 			foreach ( range( $start_page, $end_page ) as $i ) {
 				if ( $i == $paged && !empty( $options['current_text'] ) ) {
 					$current_page_text = str_replace( '%PAGE_NUMBER%', number_format_i18n( $i ), $options['current_text'] );
-					$out .= "<span class='{$class_names['current']}'>$current_page_text</span>";
+					$out .= "<span aria-current='page' class='{$class_names['current']}'>$current_page_text</span>";
 					$timeline = 'larger';
 				} else {
 					$out .= $instance->get_single( $i, $options['page_text'], array(

--- a/core.php
+++ b/core.php
@@ -211,7 +211,7 @@ function wp_pagenavi( $args = array() ) {
 			$out .= "</form>\n";
 			break;
 	}
-	$out = $before . "<" . $wrapper_tag . " class='" . $wrapper_class . "'>\n$out\n</" . $wrapper_tag . ">" . $after;
+	$out = $before . "<" . $wrapper_tag . " class='" . $wrapper_class . "' role='navigation'>\n$out\n</" . $wrapper_tag . ">" . $after;
 
 	$out = apply_filters( 'wp_pagenavi', $out );
 


### PR DESCRIPTION
Minor, but potentially significant for relevant users, addition of the ARIA 'current' role to the current page span, and 'navigation' to the wrapper.

- I chose the 'page' value as I think that would always be appropriate, but it would be swapped for 'true' to be more generic if desired.

- I didn't make the navigation role check whether the wrapper is a <nav> (with it's implicit role) as it is recommended to still use it for greatest compatibility (https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element)