### PR TITLE
Improve accessibility of nav links

### DIFF
--- a/core.php
+++ b/core.php
@@ -97,7 +97,8 @@ function wp_pagenavi( $args = array() ) {
 				// First
 				$first_text = str_replace( '%TOTAL_PAGES%', number_format_i18n( $total_pages ), __( $options['first_text'], 'wp-pagenavi' ) );
 				$out .= $instance->get_single( 1, $first_text, array(
-					'class' => $class_names['first']
+					'class' => $class_names['first'],
+					'aria-label' => __('First Page'),
 				), '%TOTAL_PAGES%' );
 			}
 
@@ -105,7 +106,8 @@ function wp_pagenavi( $args = array() ) {
 			if ( $paged > 1 && !empty( $options['prev_text'] ) ) {
 				$out .= $instance->get_single( $paged - 1, $options['prev_text'], array(
 					'class' => $class_names['previouspostslink'],
-					'rel'   => 'prev'
+					'rel'   => 'prev',
+					'aria-label' => __('Previous Page'),
 				) );
 			}
 
@@ -176,7 +178,8 @@ function wp_pagenavi( $args = array() ) {
 			if ( $paged < $total_pages && !empty( $options['next_text'] ) ) {
 				$out .= $instance->get_single( $paged + 1, $options['next_text'], array(
 					'class' => $class_names['nextpostslink'],
-					'rel'   => 'next'
+					'rel'   => 'next',
+					'aria-label' => __('Next Page'),
 				) );
 			}
 
@@ -184,6 +187,7 @@ function wp_pagenavi( $args = array() ) {
 				// Last
 				$out .= $instance->get_single( $total_pages, __( $options['last_text'], 'wp-pagenavi' ), array(
 					'class' => $class_names['last'],
+					'aria-label' => __('Last Page'),
 				), '%TOTAL_PAGES%' );
 			}
 			break;


### PR DESCRIPTION
By adding `aria-label` attributes to the first, last, next, and previous links, this improves the accessibility of the plugin when text is not defined for these fields.