### PR TITLE
Fix translations loading timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ You can do that like so:
 `<?php wp_pagenavi( array( 'options' => PageNavi_Core::$options->get_defaults() ) ); ?>`
 
 ## Changelog
+### 2.94.6
+* FIXED: Translations now runs at the proper timing, not causing triggered too early notices.
+
 ### 2.94.5
 * FIXED: WP SCB Framework now uses init hook again
 

--- a/wp-pagenavi.php
+++ b/wp-pagenavi.php
@@ -39,5 +39,7 @@ function _pagenavi_init() {
 		new PageNavi_Options_Page( __FILE__, $options );
 	}
 }
-scb_init( '_pagenavi_init' );
 
+add_action('init', function() {
+	scb_init( '_pagenavi_init' );
+});


### PR DESCRIPTION
## Pull request summary
This pull request fixes the timing error of loading text domains in the main file of the plugin by wrapping it in an init action, postponing the execution of the translations of the options. 

Error: 
```
Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the 
wp-pagenavi domain was triggered too early. This is usually an indicator for some code in 
the plugin or theme running too early. Translations should be loaded at the init action or 
later.
```

Fix in `wp-pagenavi.php`:
```
add_action('init', function() {
    scb_init( '_pagenavi_init' );
});
```

## Changelog
* FIXED: Translations now runs at the proper timing, not causing triggered too early notices.
